### PR TITLE
Debug chat

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -6,5 +6,5 @@ test:
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: seduce-me_production
+  url: <%= ENV["REDISCLOUD_URL"] %>
+  # channel_prefix: seduce-me_production

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
   config.action_cable.url = 'ws://www.seduceme.fun/cable'
-  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+  config.action_cable.allowed_request_origins = [ 'http://www.seduceme.fun', /http:\/\/seduceme.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil
-  # config.action_cable.url = 'wss://example.com/cable'
+  config.action_cable.url = 'ws://www.seduceme.fun/cable'
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,4 +10,6 @@ Rails.application.routes.draw do
   end
   get '/stories/:id/gameover', to: 'stories#gameover'
   get '/stories/:id/win', to: 'stories#win'
+
+  mount ActionCable.server => "/cable"
 end


### PR DESCRIPTION
- In 'config/environments/production.rb':
47: config.action_cable.url = 'ws://www.seduceme.fun/cable'
48: config.action_cable.allowed_request_origins = [ 'http://www.seduceme.fun', /http:\/\/seduceme.*/ ]
- In 'config/cable.yml':
9: url: <%= ENV["REDISCLOUD_URL"] %>
10: # channel_prefix: seduce-me_production
- In 'config/routes.rb':
14: mount ActionCable.server => "/cable"